### PR TITLE
ex 58

### DIFF
--- a/backend/src/services/auth.service.ts
+++ b/backend/src/services/auth.service.ts
@@ -1,10 +1,9 @@
 import * as Sentry from "@sentry/node";
-import bcrypt from "bcrypt";
 import jwt from "jsonwebtoken";
-import { User, CreateUserInput } from "../models/user.model";
-import { UserRepository } from "../repositories/user.repository";
+import { User } from "../models/user.model";
+import { userRepository } from "../repositories/user.repository";
 import { JWT_SECRET } from "../config/env";
-import { validateEmail, validateUsername, validatePassword } from "./user.service";
+import { UserService, validateEmail, validateUsername, validatePassword } from "./user.service";
 
 export interface RegisterInput {
   username: string;
@@ -23,77 +22,64 @@ export interface LoginResponse {
     accessToken: string;
     expiresIn: number;
   };
+  authentication_token: string;
 }
 
 export class AuthService {
-  async register(input: RegisterInput): Promise<Omit<User, 'passwordHash'>> {
-    console.log("Registering user:", { username: input.username, email: input.email });
+  private userService = new UserService(userRepository);
+
+  async register(input: RegisterInput): Promise<LoginResponse> {
     const username = validateUsername(input.username);
     const email = validateEmail(input.email);
     validatePassword(input.password);
 
-    const existing = await UserRepository.findByEmail(email);
-    if (existing) {
-      console.log("Registration failed: Email already exists", email);
-      throw new Error("El email ya está registrado");
-    }
-
-    const passwordHash = await bcrypt.hash(input.password, 10);
-    console.log("Password hashed successfully");
-    const userId = await UserRepository.create({
+    const user = await this.userService.registerAuthUser({
       username,
       email,
-      passwordHash,
+      password: input.password,
     });
-    console.log("User created in DB with ID:", userId);
 
-    const user = await UserRepository.findById(userId);
-    if (!user) throw new Error("Error al crear usuario");
+    const publicUser = this.userService.getPublicUser(user);
+    return this.buildResponse(publicUser);
+  }
 
+  async login(input: LoginInput): Promise<LoginResponse> {
+    const user = await this.userService.authenticate(input.email, input.password);
+
+    const now = new Date();
+    await userRepository.updateLastLogin(user.id, now);
+    user.lastLogin = now;
+
+    const publicUser = this.userService.getPublicUser(user);
+    return this.buildResponse(publicUser);
+  }
+
+  async updateProfile(userId: number, data: { display_name?: string, bio?: string, avatar_url?: string }): Promise<void> {
+    await userRepository.update(userId, data);
+  }
+
+  async getUserProfile(userId: number): Promise<Omit<User, 'passwordHash'>> {
+    const user = await userRepository.findById(userId);
+    if (!user) throw new Error("Usuario no encontrado");
     const { passwordHash: _, ...publicUser } = user;
     return publicUser;
   }
 
-  async login(input: LoginInput): Promise<LoginResponse> {
-    const user = await UserRepository.findByEmail(input.email);
-    if (!user) {
-      throw new Error("Credenciales inválidas");
-    }
-
-    const isPasswordValid = await bcrypt.compare(input.password, user.passwordHash);
-    if (!isPasswordValid) {
-      throw new Error("Credenciales inválidas");
-    }
-
-    const now = new Date();
-    await UserRepository.updateLastLogin(user.id, now);
-    user.lastLogin = now;
-
+  private buildResponse(user: Omit<User, 'passwordHash'>): LoginResponse {
     const accessToken = jwt.sign(
-      { sub: user.id.toString(), email: user.email, username: user.username },
+      { sub: user.id.toString(), email: user.email, username: user.username, role: (user as any).role },
       JWT_SECRET,
       { expiresIn: "7d", algorithm: "HS256" }
     );
 
-    const { passwordHash: _, ...publicUser } = user;
     return {
-      user: publicUser,
+      user,
       token: {
         accessToken,
         expiresIn: 7 * 24 * 60 * 60,
-      }
+      },
+      authentication_token: accessToken,
     };
-  }
-
-  async updateProfile(userId: number, data: { display_name?: string, bio?: string, avatar_url?: string }): Promise<void> {
-    await UserRepository.update(userId, data);
-  }
-
-  async getUserProfile(userId: number): Promise<Omit<User, 'passwordHash'>> {
-    const user = await UserRepository.findById(userId);
-    if (!user) throw new Error("Usuario no encontrado");
-    const { passwordHash: _, ...publicUser } = user;
-    return publicUser;
   }
 }
 

--- a/backend/src/services/user.service.ts
+++ b/backend/src/services/user.service.ts
@@ -3,6 +3,7 @@ import {
   validateEmail as ensureUfmEmail,
   validatePassword as ensureStrongPassword,
 } from '../middlewares/validateRegister.middleware';
+import bcrypt from 'bcrypt';
 
 /**
  * Validaciones básicas
@@ -30,6 +31,48 @@ export class UserService {
   private repo: any;
   constructor(userRepository: any) {
     this.repo = userRepository;
+  }
+
+  async registerAuthUser(input: { username: string; email: string; password: string }): Promise<User> {
+    const username = validateUsername(input.username);
+    const email = validateEmail(input.email);
+    validatePassword(input.password);
+
+    const existing = await this.repo.findByEmail(email);
+    if (existing) {
+      throw new Error("El email ya está registrado");
+    }
+
+    const passwordHash = await bcrypt.hash(input.password, 10);
+    const userId = await this.repo.create({
+      username,
+      email,
+      passwordHash,
+      lastLogin: null,
+    });
+
+    const created = await this.repo.findById(userId);
+    if (!created) throw new Error("Error al crear usuario");
+    return created;
+  }
+
+  async authenticate(email: string, password: string): Promise<User> {
+    const user = await this.repo.findByEmail(email);
+    if (!user) {
+      throw new Error("Credenciales inválidas");
+    }
+
+    const isPasswordValid = await bcrypt.compare(password, user.passwordHash);
+    if (!isPasswordValid) {
+      throw new Error("Credenciales inválidas");
+    }
+
+    return user;
+  }
+
+  getPublicUser(user: User): Omit<User, 'passwordHash'> {
+    const { passwordHash: _, ...publicUser } = user;
+    return publicUser;
   }
 
   async registerUserAsync(input: any): Promise<any> {


### PR DESCRIPTION
Agregar la lógica de autenticación al servicio/repositorio de user y tenerlo conectado a la BD.

El “register” ahora debe regresar un “authentication_token” y el frontend debe guardarlo en local storage (o similar) para autenticarse en todas las llamadas.