### PR TITLE
Refactor del repositorio de usuarios con Prisma

### DIFF
--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -17,6 +17,7 @@ model User {
   bio          String?    @db.Text
   display_name String?    @db.VarChar(100)
   avatar_url   String?    @db.Text
+  role         Int        @default(1)
   posts        Post[]
   post_likes   PostLike[]
 

--- a/backend/src/repositories/user.repository.ts
+++ b/backend/src/repositories/user.repository.ts
@@ -17,6 +17,7 @@ const USER_SELECT = {
     bio: true,
     display_name: true,
     avatar_url: true,
+    role: true,
     createdAt: true,
     lastLogin: true,
 } satisfies Prisma.UserSelect;
@@ -41,7 +42,7 @@ const mapUser = (user: UserRecord): User => ({
     avatar_url: user.avatar_url ?? undefined,
     createdAt: user.createdAt,
     lastLogin: user.lastLogin,
-    role: 1,
+    role: user.role,
     friends: [],
 });
 

--- a/backend/src/repositories/user.repository.ts
+++ b/backend/src/repositories/user.repository.ts
@@ -1,3 +1,4 @@
+import { Prisma } from '@prisma/client';
 import { User, UserId, CreateUserInput } from "../models/user.model";
 import prisma from "../lib/prisma";
 
@@ -8,20 +9,119 @@ export interface PublicUserProfile {
     avatar_url?: string;
 }
 
+const USER_SELECT = {
+    id: true,
+    username: true,
+    email: true,
+    passwordHash: true,
+    bio: true,
+    display_name: true,
+    avatar_url: true,
+    createdAt: true,
+    lastLogin: true,
+} satisfies Prisma.UserSelect;
+
+const PUBLIC_USER_SELECT = {
+    id: true,
+    username: true,
+    display_name: true,
+    avatar_url: true,
+} satisfies Prisma.UserSelect;
+
+type UserRecord = Prisma.UserGetPayload<{ select: typeof USER_SELECT }>;
+type PublicUserRecord = Prisma.UserGetPayload<{ select: typeof PUBLIC_USER_SELECT }>;
+
+const mapUser = (user: UserRecord): User => ({
+    id: user.id,
+    username: user.username,
+    email: user.email,
+    passwordHash: user.passwordHash,
+    bio: user.bio ?? undefined,
+    display_name: user.display_name ?? undefined,
+    avatar_url: user.avatar_url ?? undefined,
+    createdAt: user.createdAt,
+    lastLogin: user.lastLogin,
+    role: 1,
+    friends: [],
+});
+
+const mapPublicUser = (user: PublicUserRecord): PublicUserProfile => ({
+    id: user.id,
+    username: user.username,
+    display_name: user.display_name ?? undefined,
+    avatar_url: user.avatar_url ?? undefined,
+});
+
+const toRepositoryError = (error: unknown, operation: string): Error => {
+    if (error instanceof Prisma.PrismaClientKnownRequestError) {
+        if (error.code === 'P2002') {
+            const rawTarget = (error.meta as { target?: string | string[] } | undefined)?.target;
+            const targets = Array.isArray(rawTarget)
+                ? rawTarget
+                : typeof rawTarget === 'string'
+                    ? [rawTarget]
+                    : [];
+            const targetText = targets.join(',').toLowerCase();
+
+            if (targetText.includes('email')) {
+                return new Error('El email ya está registrado');
+            }
+            if (targetText.includes('username')) {
+                return new Error('El username ya está registrado');
+            }
+
+            return new Error('Registro de usuario duplicado');
+        }
+
+        if (error.code === 'P2025') {
+            return new Error('User not found');
+        }
+    }
+
+    return new Error(`Database error in users.${operation}`);
+};
+
+const runWithRepositoryErrorHandling = async <T>(
+    operation: string,
+    action: () => Promise<T>,
+): Promise<T> => {
+    try {
+        return await action();
+    } catch (error) {
+        throw toRepositoryError(error, operation);
+    }
+};
+
 export class UserRepository {
 
     static async findById(id: UserId): Promise<User | null> {
-        const user = await prisma.user.findUnique({
-            where: { id }
+        return runWithRepositoryErrorHandling('findById', async () => {
+            const user = await prisma.user.findUnique({
+                where: { id },
+                select: USER_SELECT,
+            });
+            return user ? mapUser(user) : null;
         });
-        return user as User | null;
     }
 
     static async findByEmail(email: string): Promise<User | null> {
-        const user = await prisma.user.findUnique({
-            where: { email }
+        return runWithRepositoryErrorHandling('findByEmail', async () => {
+            const user = await prisma.user.findUnique({
+                where: { email },
+                select: USER_SELECT,
+            });
+            return user ? mapUser(user) : null;
         });
-        return user as User | null;
+    }
+
+    static async findByUsername(username: string): Promise<User | null> {
+        return runWithRepositoryErrorHandling('findByUsername', async () => {
+            const user = await prisma.user.findUnique({
+                where: { username },
+                select: USER_SELECT,
+            });
+            return user ? mapUser(user) : null;
+        });
     }
 
     static async findPublicByIds(ids: UserId[]): Promise<PublicUserProfile[]> {
@@ -30,38 +130,37 @@ export class UserRepository {
             return [];
         }
 
-        const users = await prisma.user.findMany({
-            where: {
-                id: {
-                    in: uniqueIds,
+        return runWithRepositoryErrorHandling('findPublicByIds', async () => {
+            const users = await prisma.user.findMany({
+                where: {
+                    id: {
+                        in: uniqueIds,
+                    },
                 },
-            },
-            select: {
-                id: true,
-                username: true,
-                display_name: true,
-                avatar_url: true,
-            },
-        });
+                select: PUBLIC_USER_SELECT,
+            });
 
-        return users as PublicUserProfile[];
+            return users.map(mapPublicUser);
+        });
     }
 
     static async create(data: CreateUserInput): Promise<UserId> {
-        const created = await prisma.user.create({
-            data: {
-                username: data.username,
-                email: data.email,
-                passwordHash: data.passwordHash,
-                lastLogin: data.lastLogin ?? null
-            },
-            select: { id: true }
+        return runWithRepositoryErrorHandling('create', async () => {
+            const created = await prisma.user.create({
+                data: {
+                    username: data.username,
+                    email: data.email,
+                    passwordHash: data.passwordHash,
+                    lastLogin: data.lastLogin ?? null
+                },
+                select: { id: true }
+            });
+            return created.id;
         });
-        return created.id;
     }
 
     static async update(id: UserId, data: Partial<User>): Promise<void> {
-        const payload: Record<string, unknown> = {};
+        const payload: Prisma.UserUpdateInput = {};
 
         if (data.username) payload.username = data.username;
         if (data.email) payload.email = data.email;
@@ -73,22 +172,28 @@ export class UserRepository {
             return;
         }
 
-        await prisma.user.update({
-            where: { id },
-            data: payload
+        await runWithRepositoryErrorHandling('update', async () => {
+            await prisma.user.update({
+                where: { id },
+                data: payload
+            });
         });
     }
 
     static async updateLastLogin(id: UserId, date: Date): Promise<void> {
-        await prisma.user.update({
-            where: { id },
-            data: { lastLogin: date }
+        await runWithRepositoryErrorHandling('updateLastLogin', async () => {
+            await prisma.user.update({
+                where: { id },
+                data: { lastLogin: date }
+            });
         });
     }
 
     static async delete(id: UserId): Promise<void> {
-        await prisma.user.delete({
-            where: { id }
+        await runWithRepositoryErrorHandling('delete', async () => {
+            await prisma.user.delete({
+                where: { id }
+            });
         });
     }
 
@@ -101,6 +206,10 @@ export class UserRepository {
 
     async findByEmail(email: string): Promise<User | null> {
         return UserRepository.findByEmail(email);
+    }
+
+    async findByUsername(username: string): Promise<User | null> {
+        return UserRepository.findByUsername(username);
     }
 
     async findPublicByIds(ids: UserId[]): Promise<PublicUserProfile[]> {


### PR DESCRIPTION
Reescribir operaciones críticas de users para usar Prisma, unificar manejo de errores y eliminar duplicidad de acceso SQL manual.